### PR TITLE
feat : add a filtered $on, allowing easy filtering and optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/
 node_modules/
+*.log

--- a/bower.json
+++ b/bower.json
@@ -23,10 +23,10 @@
     "test"
   ],
   "dependencies": {
-    "angular": ">=1.2.0"
+    "angular": "~1.3.9"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.6",
-    "jquery": "~2.0.3"
+    "angular-mocks": "~1.3.9",
+    "jquery": "^2.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "test"
   ],
   "dependencies": {
-    "angular": "~1.3.9"
+    "angular": "~1.3.9",
+    "lodash": "~3.10.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.9",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ module.exports = function (config) {
     reporters: ['dots'],
     browsers: [process.env.TRAVIS ? 'Firefox' : 'Chrome'],
     files: [
-      'bower_components/jquery/jquery.js',
+      'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,7 @@ module.exports = function (config) {
     browsers: [process.env.TRAVIS ? 'Firefox' : 'Chrome'],
     files: [
       'bower_components/jquery/dist/jquery.js',
+      'bower_components/lodash/lodash.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Primus provider for Angular.",
   "main": "angular-primus.js",
   "scripts": {
-    "install": "bower install",
     "test": "karma start --single-run"
   },
   "repository": {
@@ -22,23 +21,24 @@
     "url": "https://github.com/neoziro/angular-primus/issues"
   },
   "devDependencies": {
-    "grunt-contrib-uglify": "~0.2.7",
-    "grunt": "~0.4.2",
-    "karma-script-launcher": "~0.1.0",
-    "karma-chrome-launcher": "~0.1.1",
-    "karma-html2js-preprocessor": "~0.1.0",
-    "karma-firefox-launcher": "~0.1.2",
-    "karma-jasmine": "~0.1.5",
-    "requirejs": "~2.1.9",
-    "karma-requirejs": "~0.2.0",
-    "karma-coffee-preprocessor": "~0.1.1",
-    "karma-phantomjs-launcher": "~0.1.1",
-    "karma": "~0.10.8",
-    "mocha": "~1.16.1",
-    "karma-mocha": "~0.1.1",
-    "chai-jquery": "~1.1.2",
-    "chai": "~1.8.1",
-    "sinon": "~1.7.3",
-    "sinon-chai": "~2.4.0"
+    "bower": "^1.5.2",
+    "chai": "^1.9.1",
+    "chai-jquery": "^1.2.3",
+    "grunt": "^0.4.5",
+    "grunt-contrib-uglify": "^0.2.7",
+    "karma": "^0.12.12",
+    "karma-chrome-launcher": "^0.1.3",
+    "karma-coffee-preprocessor": "^0.3.0",
+    "karma-firefox-launcher": "^0.1.3",
+    "karma-html2js-preprocessor": "^0.1.0",
+    "karma-jasmine": "^0.3.6",
+    "karma-mocha": "^0.1.3",
+    "karma-phantomjs-launcher": "^0.2.0",
+    "karma-requirejs": "^0.2.1",
+    "karma-script-launcher": "^0.1.0",
+    "mocha": "^1.20.1",
+    "requirejs": "^2.1.9",
+    "sinon": "^1.10.3",
+    "sinon-chai": "^2.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Primus provider for Angular.",
   "main": "angular-primus.js",
   "scripts": {
+    "postinstall": "bower update --config.interactive=false",
     "test": "karma start --single-run"
   },
   "repository": {

--- a/test/angular-primus.js
+++ b/test/angular-primus.js
@@ -18,8 +18,8 @@ describe('Primus provider', function () {
         delete self.listeners[event];
       });
 
-      this.emit = function (event) {
-        if (self.listeners[event]) self.listeners[event]();
+      this.emit = function (event, data) {
+        if (self.listeners[event]) self.listeners[event](data);
       };
 
       this._resource = {
@@ -124,6 +124,211 @@ describe('Primus provider', function () {
       primus.emit('customEvent');
 
       expect(myListener).to.not.be.called;
+    });
+  });
+
+  describe('#$filteredOn', function () {
+    var $rootScope, primus, listenerSpy, watchSpy;
+    var digestWasInProgress;
+
+    beforeEach(function() {
+    });
+
+    beforeEach(inject(function ($injector) {
+      $rootScope = $injector.get('$rootScope');
+      primus = $injector.get('primus');
+
+      digestWasInProgress = undefined;
+      listenerSpy = sinon.spy(function () {
+        digestWasInProgress = !!$rootScope.$$phase;
+      });
+
+      watchSpy = sinon.spy();
+      $rootScope.$watch(watchSpy);
+    }));
+
+    describe("filtering", function () {
+
+      describe("by properties passed as an object", function () {
+
+        it('should match correctly', function () {
+          primus.$filteredOn('customEvent', {itemId: 1}, listenerSpy);
+
+          // base
+          listenerSpy.reset();
+          primus.emit('customEvent', {itemId: 1});
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+
+          // variant
+          listenerSpy.reset();
+          primus.emit('customEvent', {
+            itemId: 1,
+            content: {
+              foo: 42
+            }
+          });
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+        });
+
+        it('should filter correctly', function () {
+          primus.$filteredOn('customEvent', {itemId: 1}, listenerSpy);
+
+          // not the same value
+          primus.emit('customEvent', {itemId: 11});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // not the same key / missing key
+          primus.emit('customEvent', {id: 1});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // nothing at all
+          primus.emit('customEvent', 42);
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+        });
+
+        it('should deep match correctly', function () {
+          primus.$filteredOn('customEvent', {content: {id: 1}}, listenerSpy);
+
+          // base
+          listenerSpy.reset();
+          primus.emit('customEvent', {content: {id: 1}});
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+
+          // variant
+          listenerSpy.reset();
+          primus.emit('customEvent', {
+            itemId: 1,
+            content: {
+              id: 1,
+              foo: 42
+            }
+          });
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+        });
+
+        it('should deep filter correctly', function () {
+          primus.$filteredOn('customEvent', {content: {id: 1}}, listenerSpy);
+
+          // not the same value
+          primus.emit('customEvent', {content: {id: 11}});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // not the same key / missing key
+          primus.emit('customEvent', {content: {itemId: 1}});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // nothing at all
+          primus.emit('customEvent', 42);
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+        });
+
+        it('should combo match correctly', function () {
+          primus.$filteredOn('customEvent', {id: 1, content: {id: 1}}, listenerSpy);
+
+          // base
+          listenerSpy.reset();
+          primus.emit('customEvent', {id: 1, content: {id: 1}});
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+
+          // variant
+          listenerSpy.reset();
+          primus.emit('customEvent', {
+            id: 1,
+            foo: 42,
+            content: {
+              id: 1,
+              bar: 33
+            }
+          });
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+        });
+
+        it('should combo filter correctly', function () {
+          primus.$filteredOn('customEvent', {id: 1, content: {id: 1}}, listenerSpy);
+
+          // not the same value - 1
+          primus.emit('customEvent', {id: 11, content: {id: 1}});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // not the same value - 2
+          primus.emit('customEvent', {id: 1, content: {id: 11}});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // missing key - 1
+          primus.emit('customEvent', {id: 1});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // missing key - 2
+          primus.emit('customEvent', {content: {id: 1}});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          // nothing at all
+          primus.emit('customEvent', 42);
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+        });
+
+      });
+
+      describe("by function", function () {
+        var testFunction = function(data) {
+          return !!(data.id % 2);
+        };
+
+        it('should match correctly', function () {
+          primus.$filteredOn('customEvent', testFunction, listenerSpy);
+
+          listenerSpy.reset();
+          primus.emit('customEvent', {id: 1});
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+
+          listenerSpy.reset();
+          primus.emit('customEvent', {id: 3});
+          expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+        });
+
+        it('should filter correctly', function () {
+          primus.$filteredOn('customEvent', testFunction, listenerSpy);
+
+          primus.emit('customEvent', {id: 0});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+
+          primus.emit('customEvent', {id: 20});
+          expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+        });
+      });
+
+    });
+
+    it('when calling callback, should wrap it in $rootScope.$apply', function () {
+      expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+      expect(watchSpy, 'watchSpy').to.not.have.been.called;
+
+      primus.$filteredOn('customEvent', {id: 1}, listenerSpy);
+      primus.emit('customEvent', {id: 1});
+
+      expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
+      expect(digestWasInProgress).to.be.true;
+      expect(watchSpy, 'watchSpy').to.have.been.calledTwice;
+    });
+
+    it('when NOT calling callback, should NOT call $rootScope.$apply', function () {
+      expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+      expect(watchSpy, 'watchSpy').to.not.have.been.called;
+
+      primus.$filteredOn('customEvent', {id: 1}, listenerSpy);
+      primus.emit('customEvent', {id: 2});
+
+      expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+      expect(watchSpy, 'watchSpy').to.not.have.been.called;
+    });
+
+    it('should return a working deregistration method', function () {
+      var off = primus.$filteredOn('customEvent', {id: 1}, listenerSpy);
+
+      off();
+      primus.emit('customEvent', {id: 1});
+
+      expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
Factor a common filtering case when handling a primus event.

Bonus : apply() is not called if the event is filtered out, greatly helping heavy AngularJS apps.

Design note : add another function instead of extending $on, for readibility and to avoid complex arguments manipulation

Note : this PR adds a dependency to lodash