### PR TITLE
feat(perfs): use $evalAsync() for calling listeners in an optimized way

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ angular.module('controllers.primus', ['primus'])
 ### about $on and $filteredOn
 
 `$filteredOn` takes as filter either :
-* a function, taking the received data as arguments and returning true/false = match/don't match
 * an object, whom keys will be deep-matched for correspondance with the 1st param of received data, using [lodash matches(...)](https://lodash.com/docs#matches). Example of a deep matching :
 
   ```javascript
   primus.$on('node:update', {content: {id: 23, type: 'image'}}, …)
   ```
+* a function, taking the received data as arguments and returning true/false = match/don't match
 
-Both `$on` and `$filteredOn` will call the listener **in Angular context** (scope.apply). However, `$filteredOn` will not trigger any apply if the received data doesn't match the given filter. This is desirable if your Angular app is heavy.
+Both `$on` and `$filteredOn` will call the listener **in Angular context**, in an optimized way via [$evalAsync](http://www.bennadel.com/blog/2751-scope-applyasync-vs-scope-evalasync-in-angularjs-1-3.htm). So if you have several listeners on the same event, they will all get executed in the same $digest phase.
+
+`$filteredOn` will not trigger any apply if the received data doesn't match the given filter. This is desirable if your Angular app is heavy.
 
 ## License
 

--- a/test/angular-primus.js
+++ b/test/angular-primus.js
@@ -101,19 +101,22 @@ describe('Primus provider', function () {
       primus = $injector.get('primus');
     }));
 
-    it('should wrap method in $rootScope.$apply', function () {
+    it('should call the listener in Angular context', function () {
       var watchSpy = sinon.spy();
       $rootScope.$watch(watchSpy);
 
-      expect(watchSpy).to.not.be.called;
+      expect(watchSpy).to.not.have.been.called;
 
       var listener = sinon.spy();
 
       primus.$on('customEvent', listener);
       primus.emit('customEvent');
+      // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+      // which won't happen in tests. Trigger it :
+      $rootScope.$digest();
 
-      expect(listener).to.be.called;
-      expect(watchSpy).to.be.called;
+      expect(listener, 'listener').to.have.been.called;
+      expect(watchSpy, 'watch').to.have.been.called;
     });
 
     it('should return a deregistration method', function () {
@@ -122,6 +125,7 @@ describe('Primus provider', function () {
 
       off();
       primus.emit('customEvent');
+      $rootScope.$digest();
 
       expect(myListener).to.not.be.called;
     });
@@ -157,6 +161,10 @@ describe('Primus provider', function () {
           // base
           listenerSpy.reset();
           primus.emit('customEvent', {itemId: 1});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
+          
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
 
           // variant
@@ -167,6 +175,8 @@ describe('Primus provider', function () {
               foo: 42
             }
           });
+          $rootScope.$digest();
+          
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
         });
 
@@ -175,14 +185,19 @@ describe('Primus provider', function () {
 
           // not the same value
           primus.emit('customEvent', {itemId: 11});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // not the same key / missing key
           primus.emit('customEvent', {id: 1});
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // nothing at all
           primus.emit('customEvent', 42);
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
         });
 
@@ -192,6 +207,9 @@ describe('Primus provider', function () {
           // base
           listenerSpy.reset();
           primus.emit('customEvent', {content: {id: 1}});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
 
           // variant
@@ -203,6 +221,7 @@ describe('Primus provider', function () {
               foo: 42
             }
           });
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
         });
 
@@ -211,14 +230,19 @@ describe('Primus provider', function () {
 
           // not the same value
           primus.emit('customEvent', {content: {id: 11}});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // not the same key / missing key
           primus.emit('customEvent', {content: {itemId: 1}});
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // nothing at all
           primus.emit('customEvent', 42);
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
         });
 
@@ -228,6 +252,9 @@ describe('Primus provider', function () {
           // base
           listenerSpy.reset();
           primus.emit('customEvent', {id: 1, content: {id: 1}});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
 
           // variant
@@ -240,6 +267,7 @@ describe('Primus provider', function () {
               bar: 33
             }
           });
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
         });
 
@@ -248,22 +276,29 @@ describe('Primus provider', function () {
 
           // not the same value - 1
           primus.emit('customEvent', {id: 11, content: {id: 1}});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // not the same value - 2
           primus.emit('customEvent', {id: 1, content: {id: 11}});
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // missing key - 1
           primus.emit('customEvent', {id: 1});
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // missing key - 2
           primus.emit('customEvent', {content: {id: 1}});
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
           // nothing at all
           primus.emit('customEvent', 42);
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
         });
 
@@ -279,10 +314,14 @@ describe('Primus provider', function () {
 
           listenerSpy.reset();
           primus.emit('customEvent', {id: 1});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
 
           listenerSpy.reset();
           primus.emit('customEvent', {id: 3});
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
         });
 
@@ -290,36 +329,46 @@ describe('Primus provider', function () {
           primus.$filteredOn('customEvent', testFunction, listenerSpy);
 
           primus.emit('customEvent', {id: 0});
+          // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+          // which won't happen in tests. Trigger it :
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
 
-          primus.emit('customEvent', {id: 20});
+          primus.emit('customEvent', {id: 20}); 
+          $rootScope.$digest();
           expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
         });
       });
 
     });
 
-    it('when calling callback, should wrap it in $rootScope.$apply', function () {
+    it('when calling callback, should call it in Angular context', function () {
       expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
       expect(watchSpy, 'watchSpy').to.not.have.been.called;
 
       primus.$filteredOn('customEvent', {id: 1}, listenerSpy);
       primus.emit('customEvent', {id: 1});
-
+      // thanks to $evalAsync, listener exec is scheduled in an angular timeout,
+      // which won't happen in tests. Trigger it :
+      $rootScope.$digest();
+      
       expect(listenerSpy, 'listenerSpy').to.have.been.calledOnce;
       expect(digestWasInProgress).to.be.true;
       expect(watchSpy, 'watchSpy').to.have.been.calledTwice;
     });
 
-    it('when NOT calling callback, should NOT call $rootScope.$apply', function () {
+    it('when NOT calling callback, should NOT trigger a $rootScope $digest', function () {
       expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
       expect(watchSpy, 'watchSpy').to.not.have.been.called;
 
       primus.$filteredOn('customEvent', {id: 1}, listenerSpy);
       primus.emit('customEvent', {id: 2});
 
-      expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
       expect(watchSpy, 'watchSpy').to.not.have.been.called;
+      $rootScope.$digest();
+
+      expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
+      expect(watchSpy, 'watchSpy').to.have.been.calledTwice; // still, due to our explicit $rootScope.$digest
     });
 
     it('should return a working deregistration method', function () {
@@ -327,6 +376,7 @@ describe('Primus provider', function () {
 
       off();
       primus.emit('customEvent', {id: 1});
+      $rootScope.$digest();
 
       expect(listenerSpy, 'listenerSpy').to.not.have.been.called;
     });


### PR DESCRIPTION
This optimization is the correct way to do it and makes #5 nearly useless.

See http://www.bennadel.com/blog/2751-scope-applyasync-vs-scope-evalasync-in-angularjs-1-3.htm for details.

If you have 10 listeners for the same event (which happen in heavy apps), those 10 listeners will now be called in the same $digest, instead of triggering 10 separate $digest.

Angular 1.3 is required and the listeners are called in a slightly different way (though it makes no difference 99.9% of the time) It can be debated as whether this is a semver API change. Recommand to version it in 2.0.0