### PR TITLE
Support Angular 1.5.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,11 +23,11 @@
     "test"
   ],
   "dependencies": {
-    "angular": "~1.4.x",
+    "angular": "~1.5.x",
     "lodash": "~3.10.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.x",
+    "angular-mocks": "~1.5.x",
     "jquery": "^2.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,11 +23,11 @@
     "test"
   ],
   "dependencies": {
-    "angular": "~1.3.9",
+    "angular": "~1.4.x",
     "lodash": "~3.10.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.3.9",
+    "angular-mocks": "~1.4.x",
     "jquery": "^2.1.0"
   }
 }


### PR DESCRIPTION
I have done an assessment of https://github.com/neoziro/angular-primus/blob/master/angular-primus.js relative to https://docs.angularjs.org/guide/migration and I don't see anything preventing this library from just bumping straight to 1.5. The currently selected 1.3.x is likely stuck in legacy-land with 1.2 - they were last updated six months ago. Seeing as 1.5 is likely to be the last chance to upgrade 1.x apps before a migration to 2.x, I think this is a reasonable change, but I don't mean to disturb the project if someone wants to leave it alone.
